### PR TITLE
Add `allowDuplicateProperties` parsing option.

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -289,6 +289,11 @@ exports.parse = (function () {
         },
         text,
 
+// If true, duplicate properties are allowed and the last definition will be used
+// e.g. '{"hello": "world1", "hello": "world2"}' -> {"hello": "world2"}
+// If false, duplicate properties result in a SyntaxError.
+        allowDuplicateProperties = true,
+
         error = function (m) {
 
 // Call error when something is wrong.
@@ -496,7 +501,8 @@ exports.parse = (function () {
                     key = string();
                     white();
                     next(':');
-                    if (Object.hasOwnProperty.call(object, key)) {
+                    if (!allowDuplicateProperties &&
+                        Object.hasOwnProperty.call(object, key)) {
                         error('Duplicate key "' + key + '"');
                     }
                     object[key] = value();
@@ -535,10 +541,11 @@ exports.parse = (function () {
 // Return the json_parse function. It will have access to all of the above
 // functions and variables.
 
-    return function (source, reviver) {
+    return function (source, reviver, _allowDuplicateProperties) {
         var result;
 
         text = source;
+        allowDuplicateProperties = _allowDuplicateProperties;
         at = 0;
         ch = ' ';
         result = value();


### PR DESCRIPTION
While discouraged, the JSON spec does allow the same property to be
present more than once in an object [1]. The built-in node.js JSON parser
allows them, but json-bignum previously did not. This option (default
false, same behavior as before) makes json-bignum behave the same way as
JSON in this respect.

For example, consider the following JSON string:

`{"hello": "world1", "hello": "world2"}`

With `allowDuplicateProperties == false`, parsing above will throw a
SyntaxError. When `true`, it will return:

`{"hello": "world2"}`

Feedback welcome; I'm a little nervous sending this without any tests.

[1] See section 2.2: "The names within an object SHOULD be unique." http://www.ietf.org/rfc/rfc4627.txt
